### PR TITLE
Fix indexing with markdown,html content type

### DIFF
--- a/app/lib/formatter.rb
+++ b/app/lib/formatter.rb
@@ -80,9 +80,9 @@ class Formatter
   end
 
   def plaintext(status)
-    return status.text if status.local?
+    return status.text if status.local? && status.content_type == 'text/plain'
 
-    text = status.text.gsub(/(<br \/>|<br>|<\/p>)+/) { |match| "#{match}\n" }
+    text = (status.local? ? format(status) : status.text).gsub(/(<br \/>|<br>|<\/p>)+/) { |match| "#{match}\n" }
     strip_tags(text)
   end
 


### PR DESCRIPTION
https://witches.live/@tribela/102902193648123681

If some user toot:
`[te](https://duckduckgo.com/?q=te)[xt](https://duckduckgo.com/?q=xt)`
It sanitised into `text` so that user can search with "text"